### PR TITLE
KakaoMapsSDK_SPM 의존성 수정

### DIFF
--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ThirdPartyExternal.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ThirdPartyExternal.swift
@@ -8,18 +8,14 @@
 import ProjectDescription
 
 public extension Array<TargetDependency> {
-    enum ThirdPartyExternal: CaseIterable {
-        case rxDataSources, kakaoMap, swiftyXMLParser
+    enum ThirdPartyExternal: String, CaseIterable {
+        case rxCocoa, swiftyXMLParser
         
         public var name: String {
-            switch self {
-            case .rxDataSources:
-                return "RxDataSources"
-            case .kakaoMap:
-                return "KakaoMapsSDK_SPM"
-            case .swiftyXMLParser:
-                return "SwiftyXMLParser"
-            }
+            var name = rawValue.map { $0 }
+            name.removeFirst()
+            name.insert(Character(rawValue.first!.uppercased()), at: 0)
+            return "\(String(name))"
         }
     }
 }

--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ThirdPartyRemote.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ThirdPartyRemote.swift
@@ -14,27 +14,23 @@ public extension Array<Package> {
 
 public extension Array<Package>.ThirdPartyRemote {
     enum SPM: CaseIterable {
-        case rxDataSources, kakaoMap, swiftyXMLParser
+        case rxSwift, swiftyXMLParser
         
         public var url: String {
             switch self {
-            case .rxDataSources:
-                return "https://github.com/RxSwiftCommunity/RxDataSources"
-            case .kakaoMap:
-                return "https://github.com/kakao-mapsSDK/KakaoMapsSDK-SPM"
+            case .rxSwift:
+                return "https://github.com/ReactiveX/RxSwift"
             case .swiftyXMLParser:
                 return "https://github.com/yahoojapan/SwiftyXMLParser"
             }
         }
         
-        public var upToNextMajor: Version {
+        public var branch: String {
             switch self {
-            case .rxDataSources:
-                return "5.0.2"
-            case .kakaoMap:
-                return "2.6.3"
+            case .rxSwift:
+                return "main"
             case .swiftyXMLParser:
-                return "5.6.0"
+                return "master"
             }
         }
     }

--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ThirdPartyRemote.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ThirdPartyRemote.swift
@@ -25,12 +25,12 @@ public extension Array<Package>.ThirdPartyRemote {
             }
         }
         
-        public var branch: String {
+        public var upToNextMajor: Version {
             switch self {
             case .rxSwift:
-                return "main"
+                return "6.0.0"
             case .swiftyXMLParser:
-                return "master"
+                return "5.6.0"
             }
         }
     }

--- a/Plugins/EnvironmentPlugin/ProjectDescriptionHelpers/Environment.swift
+++ b/Plugins/EnvironmentPlugin/ProjectDescriptionHelpers/Environment.swift
@@ -26,7 +26,7 @@ public extension String {
     static let targetVersion: Self = "16.0"
 }
 
-extension InfoPlist.Value {
+extension Plist.Value {
     static let bundleDisplayName: Self = .string(.displayName)
     static let bundleShortVersionString: Self = .string(.marketingVersion)
     static let bundleVersion: Self = .string(.buildVersion)

--- a/Plugins/EnvironmentPlugin/ProjectDescriptionHelpers/InfoPlist.swift
+++ b/Plugins/EnvironmentPlugin/ProjectDescriptionHelpers/InfoPlist.swift
@@ -44,9 +44,11 @@ public extension InfoPlist {
     )
 }
 
-public extension [String: InfoPlist.Value] {
+public extension [String: Plist.Value] {
     static let secrets: Self = [
-        "SERVER_KEY": "$(SERVER_KEY)"
+        "SERVER_KEY": "$(SERVER_KEY)",
+        "KAKAO_APP_KEY": "$(KAKAO_APP_KEY)",
+        "KAKAO_PHASE": "alpha",
     ]
     
     static let additionalInfoPlist: Self = [

--- a/Projects/ThirdPartyLibs/Project.swift
+++ b/Projects/ThirdPartyLibs/Project.swift
@@ -5,7 +5,13 @@ import ProjectDescriptionHelpers
 let project = Project.makeProject(
     name: "ThirdPartyLibs",
     moduleType: .dynamicFramework,
+    packages: [
+        .remote(
+            url: "https://github.com/kakao-mapsSDK/KakaoMapsSDK-SPM",
+            requirement: .branch("master")
+        )
+    ],
     dependencies: .ThirdPartyExternal.allCases.map {
         .external(name: $0.name)
-    }
+    } + [.package(product: "KakaoMapsSDK-SPM")]
 )

--- a/Projects/ThirdPartyLibs/Project.swift
+++ b/Projects/ThirdPartyLibs/Project.swift
@@ -13,5 +13,5 @@ let project = Project.makeProject(
     ],
     dependencies: .ThirdPartyExternal.allCases.map {
         .external(name: $0.name)
-    } + [.package(product: "KakaoMapsSDK-SPM")]
+    } + [.package(product: "KakaoMapsSDK_SPM")]
 )

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -17,7 +17,7 @@ let spm = SwiftPackageManagerDependencies(
     .ThirdPartyRemote.SPM.allCases.map {
         Package.remote(
             url: $0.url,
-            requirement: .upToNextMajor(from: $0.upToNextMajor)
+            requirement: .branch($0.branch)
         )
     }, productTypes: [
         "RxCocoa": .framework,

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -17,13 +17,12 @@ let spm = SwiftPackageManagerDependencies(
     .ThirdPartyRemote.SPM.allCases.map {
         Package.remote(
             url: $0.url,
-            requirement: .branch($0.branch)
+            requirement: .upToNextMajor(from: $0.upToNextMajor)
         )
     }, productTypes: [
         "RxCocoa": .framework,
         "RxCocoaRuntime": .framework,
-        "RxDataSources": .framework,
-        "Differentiator": .framework,
+        "SwiftyXMLParser": .framework,
     ]
 )
 

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -21,6 +21,7 @@ extension Project {
         entitlementsPath: Path? = nil,
         isTestable: Bool = false,
         hasResource: Bool = false,
+        packages: [Package] = [],
         dependencies: [TargetDependency]
     ) -> Self {
         var schemes = [Scheme]()
@@ -73,6 +74,7 @@ extension Project {
         return Project(
             name: name,
             organizationName: .organizationName,
+            packages: packages,
             targets: targets,
             schemes: schemes
         )


### PR DESCRIPTION
## 작업내용
### KakaoMapsSDK_SPM 의존성 관리 방법을 Tuist의 SPM -> Native SPM으로 수정하였습니다.
- Tuist SPM 사용시 initEngine() 메서드에서 EXC_BAD_ACCESS 런타임 에러가 발생하고 Native SPM 사용 시 정상동작 합니다.
- Objc Header File을 못 읽는 문제로 추측하였으나 같은 Header File의 코드는 잘 읽어와 문제가 아니었고 세부적인 원인은 파악하지 못했습니다.
### KakaoMaps에 필요한 InfoPlist Value를 추가하였습니다.
- KAKAO_APP_KEY
- KAKAO_PHASE
### 외부 의존성 RxDataSource -> RxCocoa로 수정하였습니다.
- RxDataSource로 TableView의 DataSource를 구성하면 커스텀 Header를 관리하지 못하여 의존성을 제거합니다.
- FirstParty인 UITableViewDataSource / UITableViewDiffableDataSource + RxSwift 사용을 권장합니다.
## 리뷰요청
- @MUKER-WON 

## 관련 이슈
close #24