### PR TITLE
Feat#/101

### DIFF
--- a/Projects/Domain/Sources/UseCase/Protocol/NearMapUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Protocol/NearMapUseCase.swift
@@ -12,9 +12,13 @@ import Foundation
 import RxSwift
 
 public protocol NearMapUseCase {
+    var nearBusStopList: PublishSubject<[BusStopInfoResponse]> { get }
     var nearByBusStop: PublishSubject<BusStopInfoResponse> { get }
     
-    func getNearByBusStop()
-    func getNearBusStopList() -> [BusStopInfoResponse]
+    func updateNearByBusStop()
+    func updateNearBusStopList(
+        longitudeRange: ClosedRange<Double>,
+        latitudeRange: ClosedRange<Double>
+    )
     func busStopSelected(busStopId: String)
 }

--- a/Projects/Feature/BusStopFeature/Sources/Coordinator/DafaultBusStopCoordinator.swift
+++ b/Projects/Feature/BusStopFeature/Sources/Coordinator/DafaultBusStopCoordinator.swift
@@ -59,13 +59,11 @@ public final class DefaultBusStopCoordinator: BusStopCoordinator {
 extension DefaultBusStopCoordinator {
     // 정류장 위치뷰로 이동하기 위한
     public func busStopMapLocation(busStopId: String) {
-        let nearMapCoordinator = coordinatorProvider
-            .makeBusStopCoordinator(
-                navigationController: navigationController,
-                busStopId: busStopId,
-                flow: flow
-            )
-        
+        let nearMapCoordinator = coordinatorProvider.makeNearMapCoordinator(
+            navigationController: navigationController,
+            flow: flow,
+            busStopId: busStopId
+        )
         childs.append(nearMapCoordinator)
         nearMapCoordinator.start()
     }

--- a/Projects/Feature/NearMapFeature/Sources/ViewController/NearMapViewController.swift
+++ b/Projects/Feature/NearMapFeature/Sources/ViewController/NearMapViewController.swift
@@ -59,19 +59,20 @@ public final class NearMapViewController: UIViewController {
 	
 	public override func viewDidLoad() {
 		super.viewDidLoad()
-		
 		viewModel.mapController = KMController(viewContainer: kakaoMapView)
 		viewModel.initKakaoMap()
 		configureUI()
 		bind()
 	}
-	
-	// MARK: - Function
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.navigationBar.topItem?.title = ""
+        navigationController?.isNavigationBarHidden = false
+    }
 	
 	public func configureUI() {
-		
-		self.navigationItem.title = "주변 정류장"
-		self.navigationController!.navigationBar.titleTextAttributes = [
+		navigationController?.navigationBar.titleTextAttributes = [
 			.font: DesignSystemFontFamily.NanumSquareNeoOTF.regular.font(
 				size: 16
 			)
@@ -169,6 +170,15 @@ public final class NearMapViewController: UIViewController {
                 }
             )
 			.disposed(by: disposeBag)
+        
+        output.navigationTitle
+            .withUnretained(self)
+            .subscribe(
+                onNext: { viewController, title in
+                    viewController.navigationItem.title = title
+                }
+            )
+            .disposed(by: disposeBag)
 	}
 }
 

--- a/Projects/Feature/NearMapFeature/Sources/ViewModel/NearMapViewModel.swift
+++ b/Projects/Feature/NearMapFeature/Sources/ViewModel/NearMapViewModel.swift
@@ -1,12 +1,13 @@
 import Foundation
+import CoreLocation
 
 import Core
 import DesignSystem
 import Domain
 import FeatureDependency
 
-import CoreLocation
 import RxSwift
+import RxRelay
 import KakaoMapsSDK
 
 public final class NearMapViewModel
@@ -17,6 +18,9 @@ public final class NearMapViewModel
     private var busStopList: [BusStopInfoResponse] = []
     
     var mapController: KMController?
+    private var mapView: KakaoMap? {
+        mapController?.getView("mapview") as? KakaoMap
+    }
     
     private var selectedBusId = PublishSubject<String>()
     private let disposeBag = DisposeBag()
@@ -37,16 +41,16 @@ public final class NearMapViewModel
 	
 	public func transform(input: Input) -> Output {
 		let output = Output(
-            selectedBusStop: useCase.nearByBusStop
+            selectedBusStop: useCase.nearByBusStop,
+            navigationTitle: .init(value: "주변 정류장")
 		)
         
         input.viewWillAppearEvent
             .withUnretained(self)
             .bind(
                 onNext: { viewModel, _ in
-                    viewModel.busStopList
-                    = viewModel.useCase.getNearBusStopList()
-                    viewModel.useCase.getNearByBusStop()
+                    viewModel.updateNearBusStopList()
+                    viewModel.useCase.updateNearByBusStop()
                 }
             )
             .disposed(by: disposeBag)
@@ -69,9 +73,7 @@ public final class NearMapViewModel
             .withUnretained(self)
             .subscribe(
                 onNext: { viewModel, _ in
-                    viewModel.makeBusIcon(
-                        responses: viewModel.busStopList
-                    )
+                    viewModel.updateNearBusStopList()
                 }
             )
             .disposed(by: disposeBag)
@@ -83,10 +85,26 @@ public final class NearMapViewModel
                     guard let longitude = Double(response.longitude),
                           let latitude = Double(response.latitude)
                     else { return }
+                    let responses = viewModel.busStopId != nil ?
+                    viewModel.busStopList :
+                    [response]
                     viewModel.moveCamera(
+                        responses: responses,
                         longitude: longitude,
                         latitude: latitude
                     )
+                    if viewModel.busStopId != nil {
+                        output.navigationTitle.accept(response.busStopName)
+                    }
+                }
+            )
+            .disposed(by: disposeBag)
+        
+        useCase.nearBusStopList
+            .withUnretained(self)
+            .subscribe(
+                onNext: { viewModel, responses in
+                    viewModel.makeBusIcon(responses: responses)
                 }
             )
             .disposed(by: disposeBag)
@@ -111,7 +129,7 @@ public final class NearMapViewModel
     }
     
     private func addBusPointStyle() {
-        guard let mapView = mapController?.getView("mapview") as? KakaoMap
+        guard let mapView
         else { return }
         
         let labelManager = mapView.getLabelManager()
@@ -145,7 +163,7 @@ public final class NearMapViewModel
     }
     
     private func makeBusIcon(responses: [BusStopInfoResponse]) {
-        guard let mapView = mapController?.getView("mapview") as? KakaoMap
+        guard let mapView
         else { return }
         
         let layer = mapView.getLabelManager()
@@ -161,13 +179,6 @@ public final class NearMapViewModel
         let maxLongitude = mapView.getPosition(viewMaxPoint).wgsCoord.longitude
         
         responses
-            .filter { response in
-                guard let longitude = Double(response.longitude),
-                      let latitude = Double(response.latitude)
-                else { return false }
-                return minLatitude...maxLatitude ~= latitude &&
-                minLongitude...maxLongitude ~= longitude
-            }
             .forEach { response in
                 guard layer?.getPoi(poiID: response.busStopId) == nil
                 else { return }
@@ -196,21 +207,51 @@ public final class NearMapViewModel
     }
     
     private func moveCamera(
+        responses: [BusStopInfoResponse],
         longitude: Double,
         latitude: Double
     ) {
-        guard let mapView = mapController?.getView("mapview") as? KakaoMap
+        guard let mapView
         else { return }
+        let cameraUpdate = CameraUpdate.make(
+            target: .init(
+                longitude: longitude,
+                latitude: latitude
+            ),
+            mapView: mapView
+        )
+        let callback: () = makeBusIcon(responses: responses)
         mapView.moveCamera(
-            .make(
-                target: .init(
-                    longitude: longitude,
-                    latitude: latitude
-                ),
-                mapView: mapView
-            )) {
-                self.makeBusIcon(responses: self.busStopList)
-            }
+            cameraUpdate,
+            callback: { callback }
+        )
+    }
+    
+    private func updateNearBusStopList() {
+        guard let mapView
+        else { return }
+        let viewMaxPoint = CGPoint(
+            x: mapView.viewRect.size.width,
+            y: mapView.viewRect.size.height
+        )
+        let minLatitude = mapView
+            .getPosition(viewMaxPoint).wgsCoord.latitude
+        let maxLatitude = mapView
+            .getPosition(.zero).wgsCoord.latitude
+        let minLongitude = mapView
+            .getPosition(.zero).wgsCoord.longitude
+        let maxLongitude = mapView
+            .getPosition(viewMaxPoint).wgsCoord.longitude
+        let longitudeRange = minLongitude < maxLongitude ?
+        minLongitude...maxLongitude :
+        maxLongitude...minLongitude
+        let latitudeRange = minLatitude < maxLatitude ?
+        minLatitude...maxLatitude :
+        maxLatitude...minLatitude
+        useCase.updateNearBusStopList(
+            longitudeRange: longitudeRange,
+            latitudeRange: latitudeRange
+        )
     }
     
     private func poiTappedHandler(_ param: PoiInteractionEventParam) {
@@ -228,12 +269,13 @@ extension NearMapViewModel: MapControllerDelegate {
 			longitude: 127.108678,
 			latitude: 37.402001
 		)
+        
 		let mapviewInfo = MapviewInfo(
 			viewName: "mapview",
 			appName: "openmap",
 			viewInfoName: "map",
 			defaultPosition: defaultPosition,
-			defaultLevel: 7
+			defaultLevel: 16
 		)
 				
 		if mapController?.addView(mapviewInfo) == Result.OK {
@@ -246,7 +288,7 @@ extension NearMapViewModel: MapControllerDelegate {
 	}
 	
 	public func containerDidResized(_ size: CGSize) {
-        guard let mapView = mapController?.getView("mapview") as? KakaoMap
+        guard let mapView
         else { return }
         mapView.viewRect = CGRect(
             origin: CGPoint(x: 0.0, y: 0.0),
@@ -264,5 +306,6 @@ extension NearMapViewModel {
     
     public struct Output {
         let selectedBusStop: PublishSubject<BusStopInfoResponse>
+        let navigationTitle: BehaviorRelay<String>
     }
 }


### PR DESCRIPTION
## 작업내용
- 전체 정류장중 주변 정류장 Filter로직 VM -> UseCase로 이동시켜 주변정류장 List를 UseCase에서 onNext해 VM에서 바인딩으로 관찰하는 형태로 수정
- 주변정류장뷰의 버스 아이콘 선택시 아이콘 색 수정
### BusStopCoordinator -> NearMapCoordinator Flow 예외처리
- NearMapVM이 더이상 Navigation 하지 않게 수정
- Navigation Title을 정류장 이름으로 수정
## 리뷰요청
- @MUKER-WON 

## 관련 이슈
close #101