### PR TITLE
[Feat] 최근 검색어, 서울, NearStopView padding

### DIFF
--- a/Projects/Feature/SearchFeature/Sources/ViewController/SearchViewController.swift
+++ b/Projects/Feature/SearchFeature/Sources/ViewController/SearchViewController.swift
@@ -40,6 +40,15 @@ public final class SearchViewController: UIViewController {
         return button
     }()
     
+    private let seoulLabel: UILabel = {
+        let label = UILabel()
+        label.font =
+        DesignSystemFontFamily.NanumSquareNeoOTF.regular.font(size: 15)
+        label.textColor = DesignSystemAsset.gray5.color
+        label.text = "서울"
+        return label
+    }()
+    
     private let tvBackgroundView = SearchTVRecentSearchBGView()
     
     private lazy var recentSearchTableView: UITableView = {
@@ -98,6 +107,7 @@ public final class SearchViewController: UIViewController {
         [
             recentSearchlabel,
             removeBtn,
+            seoulLabel,
             nearByStopPaddingView,
             nearByStopView,
             recentSearchTableView,
@@ -131,6 +141,22 @@ public final class SearchViewController: UIViewController {
                 constant: -10
             ),
             
+            seoulLabel.topAnchor.constraint(
+                equalTo: safeArea.topAnchor,
+                constant: 15
+            ),
+            seoulLabel.leadingAnchor.constraint(
+                equalTo: safeArea.leadingAnchor,
+                constant: 15
+            ),
+            seoulLabel.heightAnchor.constraint(
+                equalToConstant: 15
+            ),
+            nearByStopPaddingView.bottomAnchor.constraint(
+                equalTo: safeArea.bottomAnchor,
+                constant: -200
+            ),
+            
             nearByStopPaddingView.bottomAnchor.constraint(
                 equalTo: safeArea.bottomAnchor,
                 constant: -200
@@ -144,7 +170,7 @@ public final class SearchViewController: UIViewController {
             
             nearByStopView.topAnchor.constraint(
                 equalTo: nearByStopPaddingView.topAnchor,
-                constant: 10
+                constant: 25
             ),
             nearByStopView.centerXAnchor.constraint(
                 equalTo: safeArea.centerXAnchor
@@ -158,12 +184,12 @@ public final class SearchViewController: UIViewController {
             ),
             nearByStopView.bottomAnchor.constraint(
                 equalTo: nearByStopPaddingView.bottomAnchor,
-                constant: -10
+                constant: -25
             ),
             
             recentSearchTableView.topAnchor.constraint(
                 equalTo: recentSearchlabel.bottomAnchor,
-                constant: 10
+                constant: 0
             ),
             recentSearchTableView.leadingAnchor.constraint(
                 equalTo: safeArea.leadingAnchor
@@ -171,6 +197,7 @@ public final class SearchViewController: UIViewController {
             recentSearchTableView.trailingAnchor.constraint(
                 equalTo: safeArea.trailingAnchor
             ),
+            
             tableViewBtmConstraint,
         ])
     }
@@ -268,6 +295,15 @@ public final class SearchViewController: UIViewController {
                 }
             )
             .disposed(by: disposeBag)
+        
+        searchTextFieldView.rx.text.orEmpty
+                .map { !$0.isEmpty }
+                .bind { [weak self] hasText in
+                    self?.recentSearchlabel.isHidden = hasText
+                    self?.removeBtn.isHidden = hasText
+                    self?.seoulLabel.isHidden = !hasText
+                }
+                .disposed(by: disposeBag)
     }
     
     private func configureNavigation() {


### PR DESCRIPTION
## 작업내용
1) 주변정류장 뷰 패딩 넉넉하게 (피그마와 같이 가되, 주변 정류장이라는 타이틀은 없앤채로)

![simulator_screenshot_2FE65292-A41E-4B2D-BB4C-F1121F199463](https://github.com/Pepsi-Club/BusComing/assets/65907001/6bd274a4-c46e-4eb1-b1b0-4d418ee09703)
청

2) 검색 중에는 최근 정류장 - 삭제 사라지고 서울만 뜨게 하기

![simulator_screenshot_2ACB0C6F-6B74-4DA2-B301-4C5944E79F96](https://github.com/Pepsi-Club/BusComing/assets/65907001/0a3b2978-5966-4cdf-8e7d-5b78b3d2a4bd)

## 리뷰요청
@gnksbm 


## 관련 이슈
close #100