### PR TITLE
Fix/#108 UI 수정 및 navigation back button hidden 처리

### DIFF
--- a/Projects/DesignSystem/Resources/Assets.xcassets/TableViewColor.colorset/Contents.json
+++ b/Projects/DesignSystem/Resources/Assets.xcassets/TableViewColor.colorset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/Projects/Feature/BusStopFeature/Sources/View/BusStopInfoHeaderView.swift
+++ b/Projects/Feature/BusStopFeature/Sources/View/BusStopInfoHeaderView.swift
@@ -118,7 +118,7 @@ extension BusStopInfoHeaderView {
         NSLayoutConstraint.activate([
             busStopIcon.topAnchor.constraint(
                 equalTo: topAnchor,
-                constant: 5
+                constant: 15
             ),
             busStopIcon.widthAnchor.constraint(
                 equalToConstant: 60
@@ -147,7 +147,7 @@ extension BusStopInfoHeaderView {
             ),
             mapBtn.bottomAnchor.constraint(
                 equalTo: bottomAnchor,
-                constant: -10
+                constant: -20
             ),
             mapBtn.heightAnchor.constraint(equalToConstant: 25),
             navigationBtn.topAnchor.constraint(

--- a/Projects/Feature/BusStopFeature/Sources/ViewController/BusStopViewController.swift
+++ b/Projects/Feature/BusStopFeature/Sources/ViewController/BusStopViewController.swift
@@ -66,6 +66,10 @@ public final class BusStopViewController: UIViewController {
         configureDataSource()
     }
     
+    public override func viewWillAppear(_ animated: Bool) {
+        navigationController?.isNavigationBarHidden = true
+    }
+    
     private func bind() {
         let refreshControl = scrollView.enableRefreshControl(
             refreshStr: "당겨서 새로고침"

--- a/Projects/Feature/BusStopFeature/Sources/ViewController/BusStopViewController.swift
+++ b/Projects/Feature/BusStopFeature/Sources/ViewController/BusStopViewController.swift
@@ -30,7 +30,7 @@ public final class BusStopViewController: UIViewController {
         )
         table.delegate = self
         table.isScrollEnabled = false
-        table.backgroundColor = .systemGray6
+        table.backgroundColor = DesignSystemAsset.tableViewColor.color
         table.rowHeight = 60
         table.sectionHeaderHeight = 46
         table.sectionFooterHeight = 10


### PR DESCRIPTION
## 작업내용
1. tableview의 dark mode 처리 기존의 .systemGray6 -> DesignSystemAsset.tableViewGary.color로 변경
2. headerView의 top, bottom 여백 추가
3. NearMapVC에서 BusStopVC로 돌아올 때 생기는 navigation back button hidden 처리


## 리뷰요청
- @yuhaeun-la 

## 관련 이슈
close #108 