### PR TITLE
Fix/#110

### DIFF
--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ThirdPartyExternal.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ThirdPartyExternal.swift
@@ -9,7 +9,7 @@ import ProjectDescription
 
 public extension Array<TargetDependency> {
     enum ThirdPartyExternal: String, CaseIterable {
-        case rxCocoa, swiftyXMLParser
+        case rxCocoa
         
         public var name: String {
             var name = rawValue.map { $0 }

--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ThirdPartyRemote.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ThirdPartyRemote.swift
@@ -14,14 +14,12 @@ public extension Array<Package> {
 
 public extension Array<Package>.ThirdPartyRemote {
     enum SPM: CaseIterable {
-        case rxSwift, swiftyXMLParser
+        case rxSwift
         
         public var url: String {
             switch self {
             case .rxSwift:
                 return "https://github.com/ReactiveX/RxSwift"
-            case .swiftyXMLParser:
-                return "https://github.com/yahoojapan/SwiftyXMLParser"
             }
         }
         
@@ -29,8 +27,6 @@ public extension Array<Package>.ThirdPartyRemote {
             switch self {
             case .rxSwift:
                 return "6.0.0"
-            case .swiftyXMLParser:
-                return "5.6.0"
             }
         }
     }

--- a/Projects/CoreDataService/Sources/CoreDataService.swift
+++ b/Projects/CoreDataService/Sources/CoreDataService.swift
@@ -15,7 +15,7 @@ public protocol CoreDataService {
     
     func save(data: some CoreDataStorable) throws
     
-    func update<T: CoreDataStorable, U>(
+    func update<T: CoreDataStorable, U: Equatable>(
         data: T,
         uniqueKeyPath: KeyPath<T, U>
     ) throws
@@ -24,4 +24,10 @@ public protocol CoreDataService {
         data: T,
         uniqueKeyPath: KeyPath<T, U>
     ) throws
+    
+    func duplicationCheck<T: CoreDataStorable, U: Equatable>(
+        type: T.Type,
+        uniqueKeyPath: KeyPath<T, U>,
+        uniqueValue: U
+    ) throws -> Bool
 }

--- a/Projects/CoreDataService/Sources/DefaultCoreDataService.swift
+++ b/Projects/CoreDataService/Sources/DefaultCoreDataService.swift
@@ -100,6 +100,13 @@ public final class DefaultCoreDataService: CoreDataService {
             })
             else { return }
             container.viewContext.delete(object)
+            if container.viewContext.hasChanges {
+                do {
+                    try container.viewContext.save()
+                } catch {
+                    throw error
+                }
+            }
         } catch {
             throw error
         }

--- a/Projects/Data/Sources/Repository/DefaultFavoritesRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultFavoritesRepository.swift
@@ -33,7 +33,7 @@ public final class DefaultFavoritesRepository: FavoritesRepository {
         bus: BusArrivalInfoResponse
     ) throws {
         do {
-            var oldFavorites = try favorites.value()
+            let oldFavorites = try favorites.value()
             if let busStopToUpdate = oldFavorites
                 .first(
                     where: { 
@@ -76,7 +76,7 @@ public final class DefaultFavoritesRepository: FavoritesRepository {
         bus: BusArrivalInfoResponse
     ) throws {
         do {
-            var oldFavorites = try favorites.value()
+            let oldFavorites = try favorites.value()
             guard let busStopToRemove = oldFavorites
                 .first(
                     where: {

--- a/Projects/Data/Sources/Repository/DefaultFavoritesRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultFavoritesRepository.swift
@@ -34,12 +34,19 @@ public final class DefaultFavoritesRepository: FavoritesRepository {
     ) throws {
         do {
             let oldFavorites = try favorites.value()
-            if let busStopToUpdate = oldFavorites
-                .first(
-                    where: { 
-                        $0.busStopId == arsId
-                    }
-                ) {
+            let hasBusStopId = try coreDataService.duplicationCheck(
+                type: FavoritesBusStopResponse.self,
+                uniqueKeyPath: \.busStopId,
+                uniqueValue: arsId
+            )
+            if hasBusStopId {
+                guard let busStopToUpdate = oldFavorites
+                    .first(
+                        where: {
+                            $0.busStopId == arsId
+                        }
+                    )
+                else { return }
                 let busIdArrToUpdate = busStopToUpdate.busIds + [bus.busId]
                 let newFavorites = FavoritesBusStopResponse(
                     busStopId: busStopToUpdate.busStopId,

--- a/Projects/DesignSystem/Sources/BottomButton.swift
+++ b/Projects/DesignSystem/Sources/BottomButton.swift
@@ -14,14 +14,8 @@ public final class BottomButton: UIButton {
     ) {
         super.init(frame: .zero)
         var config = UIButton.Configuration.filled()
-        var attributeContainer = AttributeContainer()
         let font = DesignSystemFontFamily.NanumSquareNeoOTF.regular.font(
             size: 18
-        )
-        attributeContainer.font = font
-        config.attributedTitle = .init(
-            title,
-            attributes: attributeContainer
         )
         config.cornerStyle = .capsule
         config.contentInsets = .init(
@@ -29,6 +23,23 @@ public final class BottomButton: UIButton {
             leading: 0,
             bottom: 15,
             trailing: 0
+        )
+        setAttributedTitle(
+            .init(
+                string: title,
+                attributes: [.font: font]
+            ),
+            for: .normal
+        )
+        setAttributedTitle(
+            .init(
+                string: title,
+                attributes: [
+                    .font: font,
+                    .foregroundColor: DesignSystemAsset.gray4.color
+                ]
+            ),
+            for: .disabled
         )
         configuration = config
         tintColor = DesignSystemAsset.bottonBtnColor.color

--- a/Projects/Domain/Sources/UseCase/DefaultBusStopUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/DefaultBusStopUseCase.swift
@@ -59,7 +59,6 @@ public final class DefaultBusStopUseCase: BusStopUseCase {
             .observe(on: MainScheduler.asyncInstance)
             .subscribe(
                 onNext: { useCase, favorites in
-                    print("✅ \(favorites)")
                     useCase.favorites.onNext(favorites)
                 }
             )

--- a/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
@@ -29,8 +29,7 @@ public final class DefaultFavoritesUseCase: FavoritesUseCase {
     
     public func fetchFavoritesArrivals() {
         do {
-            let favoritesBusStops = try favoritesRepository.favorites
-                .value()
+            let favoritesBusStops = try favoritesRepository.favorites.value()
             Observable.combineLatest(
                 favoritesBusStops
                     .map { response in

--- a/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
@@ -40,13 +40,15 @@ public final class DefaultFavoritesUseCase: FavoritesUseCase {
                     }
             )
             .withUnretained(self)
-            .map { useCase, responses in
-                useCase.filterFavorites(
-                    fetchedResponses: responses,
-                    favoritesBusStops: favoritesBusStops
-                )
-            }
-            .bind(to: busStopArrivalInfoResponse)
+            .subscribe(
+                onNext: { useCase, responses in
+                    let filteredResponses = useCase.filterFavorites(
+                        fetchedResponses: responses,
+                        favoritesBusStops: favoritesBusStops
+                    )
+                    useCase.busStopArrivalInfoResponse.onNext(filteredResponses)
+                }
+            )
             .disposed(by: disposeBag)
         } catch {
             busStopArrivalInfoResponse.onError(error)

--- a/Projects/Feature/AlarmFeature/Sources/ViewController/AddRegularAlarmViewController.swift
+++ b/Projects/Feature/AlarmFeature/Sources/ViewController/AddRegularAlarmViewController.swift
@@ -261,26 +261,22 @@ final class AddRegularAlarmViewController: UIViewController {
             .disposed(by: disposeBag)
         
         output.regularAlarm
-            .map { response in
-                response.weekday
-            }
             .withUnretained(self)
             .subscribe(
-                onNext: { viewController, weekday in
+                onNext: { viewController, response in
                     viewController.weekDayBtns
                         .forEach { btn in
                             var color: UIColor
-                            if weekday.contains(btn.tag) {
+                            if response.weekday.contains(btn.tag) {
                                 color = DesignSystemAsset.weekDayBlue.color
                             } else {
                                 color = DesignSystemAsset.weekDayGray.color
                             }
                             btn.backgroundColor = color
                         }
-                    let completeEnabled = !weekday.isEmpty
-                    // TODO: SearchFeature에서 정보 받아오고 로직 수정
-//                    && !response.busStopName.isEmpty
-//                    && !response.busName.isEmpty
+                    let completeEnabled = !response.weekday.isEmpty
+                    && !response.busStopName.isEmpty
+                    && !response.busName.isEmpty
                     
                     viewController.completeBtn.isEnabled = completeEnabled
                 }

--- a/Projects/Feature/BusStopFeature/Sources/ViewController/BusStopViewController.swift
+++ b/Projects/Feature/BusStopFeature/Sources/ViewController/BusStopViewController.swift
@@ -91,7 +91,6 @@ public final class BusStopViewController: UIViewController {
         output.isRefreshing
             .observe(on: MainScheduler.asyncInstance)
             .subscribe(onNext: { refresh in
-                print("\(refresh)")
                 switch refresh {
                 case .fetchComplete:
                     refreshControl.endRefreshing()

--- a/Projects/Feature/HomeFeature/Sources/View/FavoritesHeaderView.swift
+++ b/Projects/Feature/HomeFeature/Sources/View/FavoritesHeaderView.swift
@@ -11,7 +11,10 @@ import UIKit
 import Core
 import DesignSystem
 
+import RxSwift
+
 internal final class FavoritesHeaderView: UITableViewHeaderFooterView {
+    var disposeBag = DisposeBag()
     private let busStopNameLabel: UILabel = {
         let label = UILabel()
         label.font = DesignSystemFontFamily.NanumSquareNeoOTF.regular.font(

--- a/Projects/Feature/HomeFeature/Sources/View/FavoritesTVCell.swift
+++ b/Projects/Feature/HomeFeature/Sources/View/FavoritesTVCell.swift
@@ -19,6 +19,8 @@ class FavoritesTVCell: UITableViewCell {
             size: 20
         )
         label.textColor = DesignSystemAsset.limeGreen.color
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.6
         return label
     }()
     

--- a/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
@@ -238,7 +238,7 @@ public final class FavoritesViewController: UIViewController {
                     )
                 }
                 viewController.headerInfoList.removeAll()
-                newResponses.enumerated().forEach { index, response in
+                newResponses.forEach { response in
                     viewController.updateHeaderInfo(
                         name: response.busStopName,
                         direction: response.direction,

--- a/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
@@ -75,7 +75,7 @@ public final class FavoritesViewController: UIViewController {
         tableView.register(FavoritesTVCell.self)
         tableView.dataSource = dataSource
         tableView.delegate = self
-        tableView.sectionHeaderTopPadding = .zero
+        tableView.sectionHeaderTopPadding = 20
         return tableView
     }()
     

--- a/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
@@ -10,10 +10,10 @@ import RxCocoa
 public final class FavoritesViewController: UIViewController {
     private let viewModel: FavoritesViewModel
     
-    private let disposeBag = DisposeBag()
-    private let headerTapEvent = PublishSubject<Int>()
+    private let headerTapEvent = PublishSubject<String>()
     private let alarmBtnTapEvent = PublishSubject<IndexPath>()
     private let isTableViewEditMode = BehaviorSubject(value: false)
+    private let disposeBag = DisposeBag()
     
     private var dataSource: FavoritesDataSource!
     private var snapshot: FavoritesSnapshot!
@@ -237,16 +237,12 @@ public final class FavoritesViewController: UIViewController {
                         }
                     )
                 }
-                newResponses.forEach { response in
+                viewController.headerInfoList.removeAll()
+                newResponses.enumerated().forEach { index, response in
                     viewController.updateHeaderInfo(
                         name: response.busStopName,
-                        direction: response.direction
-                    )
-                    let header = viewController.favoritesTableView
-                        .tableHeaderView as? FavoritesHeaderView
-                    header?.updateUI(
-                        name: response.busStopName,
-                        direction: response.direction
+                        direction: response.direction,
+                        busStopId: response.busStopId
                     )
                 }
                 viewController.updateSnapshot(busStopResponse: newResponses)
@@ -348,12 +344,14 @@ public final class FavoritesViewController: UIViewController {
     
     private func updateHeaderInfo(
         name: String,
-        direction: String
+        direction: String,
+        busStopId: String
     ) {
         headerInfoList += [
             [
                 "name": name,
-                "direction": direction
+                "direction": direction,
+                "busStopId": busStopId
             ]
         ]
     }
@@ -405,21 +403,25 @@ extension FavoritesViewController: UITableViewDelegate {
         _ tableView: UITableView,
         viewForHeaderInSection section: Int
     ) -> UIView? {
-        let header = tableView.dequeueReusableHeaderFooterView(
+        guard let header = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: FavoritesHeaderView.identifier
         ) as? FavoritesHeaderView
+        else { return .init() }
         if section < headerInfoList.count {
-            header?.updateUI(
+            header.updateUI(
                 name: headerInfoList[section]["name"],
                 direction: headerInfoList[section]["direction"]
             )
         }
+        guard let busStopId = headerInfoList[section]["busStopId"]
+        else { return header }
         let tapGesture = UITapGestureRecognizer()
-        header?.contentView.addGestureRecognizer(tapGesture)
+        header.contentView.addGestureRecognizer(tapGesture)
+        header.disposeBag = .init()
         tapGesture.rx.event
-            .map { _ in section }
+            .map { _ in busStopId }
             .bind(to: headerTapEvent)
-            .disposed(by: disposeBag)
+            .disposed(by: header.disposeBag)
         return header
     }
 }

--- a/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
@@ -64,12 +64,18 @@ public final class FavoritesViewModel: ViewModel {
         input.busStopTapEvent
             .withUnretained(self)
             .subscribe(
-                onNext: { viewModel, sectionIndex in
+                onNext: { viewModel, selectedId in
                     do {
-                        let response = try viewModel.useCase
+                        let responses = try viewModel.useCase
                             .busStopArrivalInfoResponse.value()
+                        guard let selectedBusStop = responses.first(
+                            where: { response in
+                                response.busStopId == selectedId
+                            }
+                        )
+                        else { return }
                         viewModel.coordinator.startBusStopFlow(
-                            stationId: response[sectionIndex].busStopId
+                            stationId: selectedBusStop.busStopId
                         )
                     } catch {
                         print(error.localizedDescription)
@@ -121,7 +127,7 @@ extension FavoritesViewModel {
         let searchBtnTapEvent: Observable<Void>
         let refreshBtnTapEvent: Observable<Void>
         let alarmBtnTapEvent: Observable<IndexPath>
-        let busStopTapEvent: Observable<Int>
+        let busStopTapEvent: Observable<String>
     }
     
     public struct Output {

--- a/Projects/Feature/SearchFeature/Sources/ViewController/SearchViewController.swift
+++ b/Projects/Feature/SearchFeature/Sources/ViewController/SearchViewController.swift
@@ -222,15 +222,11 @@ public final class SearchViewController: UIViewController {
             .filter { _ in
                 output.tableViewSection.value == .recentSearch
             }
-            .withLatestFrom(output.tableViewSection) { responses, section in
-                (responses, section)
-            }
             .withUnretained(self)
             .subscribe(
-                onNext: { viewController, tuple in
-                    let (responses, section) = tuple
+                onNext: { viewController, responses in
                     viewController.updateSnapshot(
-                        section: section,
+                        section: .recentSearch,
                         responses: responses
                     )
                 }
@@ -241,15 +237,11 @@ public final class SearchViewController: UIViewController {
             .filter { _ in
                 output.tableViewSection.value == .searchedData
             }
-            .withLatestFrom(output.tableViewSection) { responses, section in
-                (responses, section)
-            }
             .withUnretained(self)
             .subscribe(
-                onNext: { viewController, tuple in
-                    let (responses, section) = tuple
+                onNext: { viewController, responses in
                     viewController.updateSnapshot(
-                        section: section,
+                        section: .searchedData,
                         responses: responses
                     )
                 }

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -22,7 +22,6 @@ let spm = SwiftPackageManagerDependencies(
     }, productTypes: [
         "RxCocoa": .framework,
         "RxCocoaRuntime": .framework,
-        "SwiftyXMLParser": .framework,
     ]
 )
 


### PR DESCRIPTION
## 작업내용
### HomeFeature
- 즐겨찾기 Header 업데이트 로직 수정
- 즐겨찾기 TableView Section 간격 추가
- 즐겨찾기 버스노선번호 크기 동적 사이즈로 수정
### AlarmFeature
- BottomButton 비활성화 상태 textColor 수정
- 알람 추가 뷰의 버튼 선택된 정류장이 없을 때 비활성화
### CoreDataService
- CoreDataService 저장 로직 수정, 중복 확인 함수 추가
- CoreDataService update, delete 로직 수정
  - 수정 전 잘못된 로직
  - update: CoreData에 저장된 정류장중 첫번째 데이터를 update 요청한 busStopId와 busId로 변경하여 저장해 즐겨찾기 뷰에 중복된 데이터 전달(DiffableDataSource 런타임 에러)
  - delete: 로직이 viewContext에 저장하지 않아 FavoritesRepository만 업데이트되어 앱 재시작시 변경되지 않은 CoreData 모델을 fetch
### Tuist
- API 변경전 XML 파싱을 위해 사용하던 SwiftyXMLParser 의존성 제거
## 리뷰요청
- @isakatty 
## 관련 이슈
close #110