### PR TITLE
Fix/#109

### DIFF
--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -17,6 +17,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         setupAppearance()
         registerDependencies()
         configureNotification(application: application)
+        
+        UIBarButtonItem.appearance().setBackButtonTitlePositionAdjustment(UIOffset(horizontal: -1000, vertical: 0), for: .default)
+
         return true
     }
 

--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -18,6 +18,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         registerDependencies()
         configureNotification(application: application)
         
+        //모든 BackButton의 타이틀을 없애버림 
         UIBarButtonItem.appearance().setBackButtonTitlePositionAdjustment(UIOffset(horizontal: -1000, vertical: 0), for: .default)
 
         return true

--- a/Projects/Feature/SearchFeature/Sources/View/Cell/SearchTVCell.swift
+++ b/Projects/Feature/SearchFeature/Sources/View/Cell/SearchTVCell.swift
@@ -40,7 +40,8 @@ final class SearchTVCell: UITableViewCell {
         style: UITableViewCell.CellStyle,
         reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-    
+        
+        backgroundColor = .white
         configureUI()
     }
     

--- a/Projects/Feature/SearchFeature/Sources/View/DeagreeSearchNearStopView.swift
+++ b/Projects/Feature/SearchFeature/Sources/View/DeagreeSearchNearStopView.swift
@@ -63,6 +63,7 @@ final class DeagreeSearchNearStopView: UIButton {
         let label = UILabel()
         label.font =
         DesignSystemFontFamily.NanumSquareNeoOTF.bold.font(size: 16)
+        label.textColor = .black
         label.text = "주변정류장"
         
         return label

--- a/Projects/Feature/SearchFeature/Sources/View/SearchNearStopView.swift
+++ b/Projects/Feature/SearchFeature/Sources/View/SearchNearStopView.swift
@@ -62,6 +62,7 @@ final class SearchNearStopView: UIButton {
         let label = UILabel()
         label.font =
         DesignSystemFontFamily.NanumSquareNeoOTF.bold.font(size: 16)
+        label.textColor = .black
         label.text = "주변정류장"
         
         return label

--- a/Projects/Feature/SearchFeature/Sources/View/SearchTextFieldView.swift
+++ b/Projects/Feature/SearchFeature/Sources/View/SearchTextFieldView.swift
@@ -37,10 +37,18 @@ public final class SearchTextFieldView: UITextField {
         self.addLeftPadding()
         self.autocorrectionType = .no
         self.spellCheckingType = .no
+        self.textColor = .black
+        
     }
     
     private func setPlaceholder(_ placeholder: String?) {
         self.placeholder = " 버스 정류장을 검색하세요"
+        self.attributedPlaceholder = NSAttributedString(
+            string: self.placeholder ?? "",
+            attributes:
+                [NSAttributedString.Key.foregroundColor:
+                    DesignSystemAsset.gray4.color]
+        )
     }
 }
 

--- a/Projects/Feature/SearchFeature/Sources/ViewController/SearchViewController.swift
+++ b/Projects/Feature/SearchFeature/Sources/ViewController/SearchViewController.swift
@@ -57,6 +57,7 @@ public final class SearchViewController: UIViewController {
             style: .insetGrouped
         )
         table.register(SearchTVCell.self)
+        table.backgroundColor = DesignSystemAsset.tableViewColor.color
         table.dataSource = dataSource
         return table
     }()
@@ -87,6 +88,7 @@ public final class SearchViewController: UIViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
+        
         configureUI()
         configureDataSource()
         bind()
@@ -282,6 +284,9 @@ public final class SearchViewController: UIViewController {
                                 equalTo: viewController.view.safeAreaLayoutGuide
                                     .bottomAnchor
                             )
+                        viewController.recentSearchTableView.contentInset.top
+                        = -40
+                        
                     }
                     viewController.tableViewBtmConstraint.isActive = true
                 }


### PR DESCRIPTION
## 작업내용
- [x] 다크모드 대응
- [x] 최근 검색 정류장, 서울 Bottom Padding
- [x] AddAlarm -> Search Flow에서 BackBtn 이름 살아남
- [x] 최근 검색어, 삭제 - topAnchor 널널하게
- [x] 위치정보허용 없을 때 pin으로 변경

## 리뷰요청
- @MUKER-WON 

데브에서 작업한줄 모르고 커밋해서 (죄송합니다)부랴부랴 강묵님께서 리뷰해주셨으면 하는 부분만 추가해서 가져왔습니다 !

 **AddAlarm -> Search Flow에서 BackBtn 이름 살아남**
이 부분 처리를 위해서 앱 내에 모든 네비게이션 BackButton의 tiltle을 없애는 코드를 넣었는데 강묵님 쪽 viewController에
  

>   viewController.navigationItem.title = title

와 같은 네비게이션 타이틀이 필요한 코드가 보여 리뷰 요청 드립니다! 혹시 이 코드가 현재 필수적으로 사용되고 있다면 제 코드를 바꿔야할거 같아요! 

## 관련 이슈
close #109 