### PR TITLE
Fix/#131

### DIFF
--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -17,10 +17,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         setupAppearance()
         registerDependencies()
         configureNotification(application: application)
-        
-        //모든 BackButton의 타이틀을 없애버림
-        UIBarButtonItem.appearance().setBackButtonTitlePositionAdjustment(UIOffset(horizontal: -1000, vertical: 0), for: .default)
-
         return true
     }
 

--- a/Projects/Data/Sources/Repository/DefaultStationListRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultStationListRepository.swift
@@ -59,12 +59,9 @@ public final class DefaultStationListRepository: StationListRepository {
         recentlySearchedStation.accept([])
     }
     
-    /// 현재위치로 부터 가장 가까운 정류장을 구합니다.
-    /// nearBusStop: 가장 가까운 정류장
-    /// distance: 떨어진 거리(m,km)
     public func getNearByStopInfo(
         startPointLocation: CLLocation
-    ) -> BusStopInfoResponse {
+    ) -> (BusStopInfoResponse, String) {
         let errorResponse = BusStopInfoResponse(
             busStopName: "가까운 정류장을 찾을 수 없습니다.",
             busStopId: "",
@@ -92,9 +89,18 @@ public final class DefaultStationListRepository: StationListRepository {
                     nearByStopDistance = distance
                 }
             }
-            return nearByStop
+            let distanceStr: String
+            switch nearByStopDistance {
+            case ..<1000:
+                distanceStr = "\(nearByStopDistance)m"
+            case Int.max:
+                distanceStr = "측정거리 초과"
+            default:
+                distanceStr =  "\(nearByStopDistance / 1000)km"
+            }
+            return (nearByStop, distanceStr)
         } catch {
-            return errorResponse
+            return (errorResponse, errorDistance)
         }
     }
     

--- a/Projects/Data/Sources/Service/LocationService/DefaultLocationService.swift
+++ b/Projects/Data/Sources/Service/LocationService/DefaultLocationService.swift
@@ -21,7 +21,12 @@ final public class DefaultLocationService: NSObject, LocationService {
         value: locationManager.authorizationStatus
     )
     
-    public lazy var currentLocation = PublishSubject<CLLocation>()
+    public lazy var currentLocation = BehaviorSubject<CLLocation>(
+        value: .init(
+            latitude: 126.979620,
+            longitude: 37.570028
+        )
+    )
     
     private let disposeBag = DisposeBag()
     
@@ -80,5 +85,35 @@ extension DefaultLocationService: CLLocationManagerDelegate {
         didFailWithError error: Error
     ) {
         currentLocation.onError(error)
+    }
+    
+    public func getDistance(response: BusStopInfoResponse) -> String {
+        let errorMessage = ""
+        guard let latitude = Double(response.latitude),
+              let longitude = Double(response.longitude)
+        else { return errorMessage }
+        do {
+            let currentLocation = try currentLocation.value()
+            let distance = Int(
+                currentLocation.distance(
+                    from: .init(
+                        latitude: latitude,
+                        longitude: longitude
+                    )
+                )
+            )
+            let distanceStr: String
+            switch distance {
+            case ..<1000:
+                distanceStr = "\(distance)m"
+            case Int.max:
+                distanceStr = "측정거리 초과"
+            default:
+                distanceStr =  "\(distance / 1000)km"
+            }
+            return distanceStr
+        } catch {
+            return errorMessage
+        }
     }
 }

--- a/Projects/DesignSystem/Sources/Appearance.swift
+++ b/Projects/DesignSystem/Sources/Appearance.swift
@@ -20,5 +20,10 @@ public final class Appearance {
         UITabBar.appearance().tintColor = accentColor
         UITabBar.appearance().unselectedItemTintColor = mainColor
         UITabBar.appearance().isTranslucent = false
+        //모든 BackButton의 타이틀을 없애버림
+        UIBarButtonItem.appearance().setBackButtonTitlePositionAdjustment(
+            UIOffset(horizontal: -1000, vertical: 0),
+            for: .default
+        )
     }
 }

--- a/Projects/Domain/Sources/LocationService/LocationService.swift
+++ b/Projects/Domain/Sources/LocationService/LocationService.swift
@@ -14,10 +14,11 @@ import RxRelay
 
 public protocol LocationService {
 	var authState: BehaviorSubject<CLAuthorizationStatus> { get }
-	var currentLocation: PublishSubject<CLLocation> { get }
+	var currentLocation: BehaviorSubject<CLLocation> { get }
 	
     func authorize()
 	func requestLocationOnce()
 	func startUpdatingLocation()
 	func stopUpdatingLocation()
+    func getDistance(response: BusStopInfoResponse) -> String
 }

--- a/Projects/Domain/Sources/RepositoryInterface/StationListRepository.swift
+++ b/Projects/Domain/Sources/RepositoryInterface/StationListRepository.swift
@@ -20,5 +20,5 @@ public protocol StationListRepository {
     func removeRecentSearch()
     func getNearByStopInfo(
         startPointLocation: CLLocation
-    ) -> BusStopInfoResponse
+    ) -> (BusStopInfoResponse, String)
 }

--- a/Projects/Domain/Sources/UseCase/DefaultNearMapUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/DefaultNearMapUseCase.swift
@@ -16,141 +16,115 @@ public final class DefaultNearMapUseCase: NearMapUseCase {
     private let stationListRepository: StationListRepository
     private let locationService: LocationService
     
-    public let nearBusStopList = PublishSubject<[BusStopInfoResponse]>()
-    public let selectedBusStop = PublishSubject<BusStopInfoResponse>()
-    public let distanceFromNearByStop = PublishSubject<String>()
     private let disposeBag = DisposeBag()
-	
+    
     public init(
         stationListRepository: StationListRepository,
         locationService: LocationService
     ) {
         self.stationListRepository = stationListRepository
-		self.locationService = locationService
-        bindDistance()
+        self.locationService = locationService
     }
     
-    public func updateNearByBusStop() {
-        locationService.currentLocation
-            .take(1)
-            .subscribe(
-                with: self,
-                onNext: { useCase, location in
-                    let nearBusStop = useCase.stationListRepository
-                        .getNearByStopInfo(startPointLocation: location)
-                    useCase.selectedBusStop.onNext(nearBusStop)
-                }
-            )
-            .disposed(by: disposeBag)
-        
+    public func requestAuthorize() {
+        locationService.authorize()
+    }
+    
+    public func getNearByStopInfo(
+    ) -> Observable<(BusStopInfoResponse, String)> {
         locationService.authState
-            .withUnretained(self)
-            .subscribe(
-                onNext: { useCase, authState in
-                    switch authState {
-                    case .notDetermined:
-                        useCase.locationService.authorize()
-                    case .restricted:
-                        let desciption = "오류가 발생했습니다. 관리자에게 문의해주세요."
-                        let result = BusStopInfoResponse(
-                            busStopName: desciption,
-                            busStopId: "",
-                            direction: "",
-                            longitude: "",
-                            latitude: ""
-                        )
-                        useCase.selectedBusStop.onNext(result)
-                    case .denied:
-                        let desciption = "주변 정류장을 확인하려면 위치 정보를 동의해주세요."
-                        let result = BusStopInfoResponse(
-                            busStopName: desciption,
-                            busStopId: "",
-                            direction: "",
-                            longitude: "",
-                            latitude: ""
-                        )
-                        useCase.selectedBusStop.onNext(result)
-                    case .authorizedAlways, .authorizedWhenInUse:
-                        useCase.locationService.requestLocationOnce()
-                    @unknown default:
-                        break
-                    }
-                }
-            )
-            .disposed(by: disposeBag)
-    }
-    
-    public func updateNearBusStopList(
-        longitudeRange: ClosedRange<Double>,
-        latitudeRange: ClosedRange<Double>
-    ) {
-        stationListRepository.stationList
-            .map { responses in
-                responses.filter { response in
-                    guard let longitude = Double(response.longitude),
-                          let latitude = Double(response.latitude)
-                    else { return false }
-                    return longitudeRange ~= longitude &&
-                    latitudeRange ~= latitude
-                }
+            .withLatestFrom(
+                locationService.currentLocation
+            ) { status, location in
+                (status, location)
             }
             .withUnretained(self)
-            .subscribe(
-                onNext: { useCase, filteredList in
-                    useCase.nearBusStopList.onNext(filteredList)
+            .map { useCase, tuple in
+                let (status, location) = tuple
+                var response: BusStopInfoResponse
+                var distanceStr: String
+                let requestMessage = "주변 정류장을 확인하려면 위치 정보를 동의해주세요."
+                let errorMessage = "오류가 발생했습니다. 관리자에게 문의해주세요."
+                switch status {
+                case .authorizedAlways, .authorizedWhenInUse:
+                    (response, distanceStr) = useCase.stationListRepository
+                            .getNearByStopInfo(startPointLocation: location)
+                case .notDetermined, .denied:
+                    response = .init(
+                        busStopName: requestMessage,
+                        busStopId: "",
+                        direction: "",
+                        longitude: "",
+                        latitude: ""
+                    )
+                    distanceStr = ""
+                case .restricted:
+                    response = .init(
+                        busStopName: errorMessage,
+                        busStopId: "",
+                        direction: "",
+                        longitude: "",
+                        latitude: ""
+                    )
+                    distanceStr = ""
+                @unknown default:
+                    response = .init(
+                        busStopName: errorMessage,
+                        busStopId: "",
+                        direction: "",
+                        longitude: "",
+                        latitude: ""
+                    )
+                    distanceStr = ""
                 }
-            )
-            .disposed(by: disposeBag)
+                return (response, distanceStr)
+            }
     }
     
-    public func busStopSelected(busStopId: String) {
+    public func getSelectedBusStop(
+        busStopId: String
+    ) -> (BusStopInfoResponse, String) {
+        let errorResponse = BusStopInfoResponse(
+            busStopName: "정류장 정보를 찾을 수 없습니다.",
+            busStopId: "",
+            direction: "",
+            longitude: "",
+            latitude: ""
+        )
+        let errorDistance = ""
         do {
-            let responses = try stationListRepository.stationList.value()
-            guard let response = responses.first(
-                where: { response in
-                    response.busStopId == busStopId
-                }
-            )
-            else { return }
-            selectedBusStop.onNext(response)
+            let stationList = try stationListRepository.stationList.value()
+            let selectedBusStop = stationList.first { response in
+                response.busStopId == busStopId
+            }
+            if let selectedBusStop {
+                let distance = locationService.getDistance(
+                    response: selectedBusStop
+                )
+                return (selectedBusStop, distance)
+            } else {
+                return (errorResponse, errorDistance)
+            }
         } catch {
-            print(error.localizedDescription)
+            return (errorResponse, errorDistance)
         }
     }
     
-    private func bindDistance() {
-        selectedBusStop
-            .withLatestFrom(
-                locationService.currentLocation
-            ) { response, location in
-                (response, location)
+    public func getNearBusStopList(
+        longitudeRange: ClosedRange<Double>,
+        latitudeRange: ClosedRange<Double>
+    ) -> [BusStopInfoResponse] {
+        do {
+            let stationList = try stationListRepository.stationList.value()
+            return stationList.filter { response in
+                guard let longitude = Double(response.longitude),
+                      let latitude = Double(response.latitude)
+                else { return false }
+                return longitudeRange ~= longitude &&
+                latitudeRange ~= latitude
             }
-            .withUnretained(self)
-            .subscribe(
-                onNext: { useCase, tuple in
-                    let (response, startPoint) = tuple
-                    guard let endPointLatitude = Double(response.latitude),
-                          let endPointLongitude = Double(response.longitude)
-                    else { return }
-                    let distance = Int(
-                        CLLocation(
-                            latitude: endPointLatitude,
-                            longitude: endPointLongitude
-                        )
-                        .distance(from: startPoint)
-                    )
-                    let distanceStr: String
-                    switch distance {
-                    case ..<1000:
-                        distanceStr = "\(distance)m"
-                    case Int.max:
-                        distanceStr = "측정거리 초과"
-                    default:
-                        distanceStr =  "\(distance / 1000)km"
-                    }
-                    useCase.distanceFromNearByStop.onNext(distanceStr)
-                }
-            )
-            .disposed(by: disposeBag)
+        } catch {
+            return []
+        }
     }
 }

--- a/Projects/Domain/Sources/UseCase/Protocol/NearMapUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Protocol/NearMapUseCase.swift
@@ -12,14 +12,14 @@ import Foundation
 import RxSwift
 
 public protocol NearMapUseCase {
-    var nearBusStopList: PublishSubject<[BusStopInfoResponse]> { get }
-    var selectedBusStop: PublishSubject<BusStopInfoResponse> { get }
-    var distanceFromNearByStop: PublishSubject<String> { get }
-    
-    func updateNearByBusStop()
-    func updateNearBusStopList(
+    func requestAuthorize()
+    func getNearByStopInfo(
+    ) -> Observable<(BusStopInfoResponse, String)>
+    func getSelectedBusStop(
+        busStopId: String
+    ) -> (BusStopInfoResponse, String)
+    func getNearBusStopList(
         longitudeRange: ClosedRange<Double>,
         latitudeRange: ClosedRange<Double>
-    )
-    func busStopSelected(busStopId: String)
+    ) -> [BusStopInfoResponse]
 }

--- a/Projects/Domain/Sources/UseCase/Protocol/SearchUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Protocol/SearchUseCase.swift
@@ -11,8 +11,7 @@ import Foundation
 import RxSwift
 
 public protocol SearchUseCase {
-    var nearByStop: PublishSubject<BusStopInfoResponse> { get }
-    var distanceFromNearByStop: PublishSubject<String> { get }
+    var nearByStopInfo: PublishSubject<(BusStopInfoResponse, String)> { get }
     var searchedStationList: PublishSubject<[BusStopInfoResponse]> { get }
     var recentSearchResult: BehaviorSubject<[BusStopInfoResponse]> { get }
     

--- a/Projects/Feature/NearMapFeature/Sources/Coordinator/DafaultNearMapCoordinator.swift
+++ b/Projects/Feature/NearMapFeature/Sources/Coordinator/DafaultNearMapCoordinator.swift
@@ -14,8 +14,6 @@ public final class DefaultNearMapCoordinator: NearMapCoordinator {
     public let busStopId: String?
     public var coordinatorType: CoordinatorType = .nearMap
     
-    private let disposeBag = DisposeBag()
-    
     public init(
         parent: Coordinator?,
         navigationController: UINavigationController,
@@ -57,5 +55,4 @@ extension DefaultNearMapCoordinator {
         childs.append(busStopCoordinator)
         busStopCoordinator.start()
     }
-	
 }

--- a/Projects/Feature/NearMapFeature/Sources/View/BusStopInformationView.swift
+++ b/Projects/Feature/NearMapFeature/Sources/View/BusStopInformationView.swift
@@ -175,9 +175,6 @@ public final class BusStopInformationView: UIView {
         !response.direction.isEmpty ?
         "\(response.busStopId) | \(response.direction) 방면" : ""
         busStopDescription.text = description
-    }
-    
-    func updateUI(distance: String) {
         distanceFromBusStopLabel.text = distance
     }
 }

--- a/Projects/Feature/NearMapFeature/Sources/ViewModel/NearMapViewModel.swift
+++ b/Projects/Feature/NearMapFeature/Sources/ViewModel/NearMapViewModel.swift
@@ -284,7 +284,7 @@ public final class NearMapViewModel
             ),
             mapView: mapView
         )
-        let callback = {   }
+        let callback = { self.updateNearBusStopList() }
         mapView.moveCamera(
             cameraUpdate,
             callback: callback

--- a/Projects/Feature/SearchFeature/Sources/View/DeagreeSearchNearStopView.swift
+++ b/Projects/Feature/SearchFeature/Sources/View/DeagreeSearchNearStopView.swift
@@ -75,14 +75,10 @@ final class DeagreeSearchNearStopView: UIButton {
     }
     
     func updateUI(
-        busStopName: String
-    ) {
-        nearStopNameLabel.text = busStopName
-    }
-    
-    func updateUI(
+        busStopName: String,
         distance: String
     ) {
+        nearStopNameLabel.text = busStopName
         distanceLabel.text = distance
     }
     

--- a/Projects/Feature/SearchFeature/Sources/ViewController/SearchViewController.swift
+++ b/Projects/Feature/SearchFeature/Sources/ViewController/SearchViewController.swift
@@ -243,22 +243,13 @@ public final class SearchViewController: UIViewController {
             )
             .disposed(by: disposeBag)
         
-        output.nearByStop
+        output.nearByStopInfo
             .withUnretained(self)
             .subscribe(
-                onNext: { viewController, nearByStop in
+                onNext: { viewController, tuple in
+                    let (response, distance) = tuple
                     viewController.nearByStopView.updateUI(
-                        busStopName: nearByStop.busStopName
-                    )
-                }
-            )
-            .disposed(by: disposeBag)
-        
-        output.distanceFromNearByStop
-            .withUnretained(self)
-            .subscribe(
-                onNext: { viewController, distance in
-                    viewController.nearByStopView.updateUI(
+                        busStopName: response.busStopName,
                         distance: distance
                     )
                 }

--- a/Projects/Feature/SearchFeature/Sources/ViewModel/SearchViewModel.swift
+++ b/Projects/Feature/SearchFeature/Sources/ViewModel/SearchViewModel.swift
@@ -26,8 +26,7 @@ public final class SearchViewModel: ViewModel {
         let output = Output(
             searchedResponse: useCase.searchedStationList,
             recentSearchedResponse: .init(value: []),
-            nearByStop: .init(),
-            distanceFromNearByStop: .init(),
+            nearByStopInfo: .init(),
             tableViewSection: .init(value: .recentSearch)
         )
         
@@ -97,11 +96,8 @@ public final class SearchViewModel: ViewModel {
             .bind(to: output.recentSearchedResponse)
             .disposed(by: disposeBag)
         
-        useCase.nearByStop
-            .bind(to: output.nearByStop)
-            .disposed(by: disposeBag)
-        useCase.distanceFromNearByStop
-            .bind(to: output.distanceFromNearByStop)
+        useCase.nearByStopInfo
+            .bind(to: output.nearByStopInfo)
             .disposed(by: disposeBag)
         
         return output
@@ -120,8 +116,7 @@ extension SearchViewModel {
     public struct Output {
         var searchedResponse: PublishSubject<[BusStopInfoResponse]>
         var recentSearchedResponse: BehaviorSubject<[BusStopInfoResponse]>
-        var nearByStop: PublishSubject<BusStopInfoResponse>
-        var distanceFromNearByStop: PublishSubject<String>
+        var nearByStopInfo: PublishSubject<(BusStopInfoResponse, String)>
         var tableViewSection: BehaviorRelay<SearchSection>
     }
 }

--- a/Projects/FeatureDependency/Sources/Mock/MockLocationService.swift
+++ b/Projects/FeatureDependency/Sources/Mock/MockLocationService.swift
@@ -19,7 +19,12 @@ public final class MockLocationService: LocationService {
         value: .notDetermined
     )
     
-    public let currentLocation = PublishSubject<CLLocation>()
+    public let currentLocation = BehaviorSubject<CLLocation>(
+        value: .init(
+            latitude: 126.979620,
+            longitude: 37.570028
+        )
+    )
     
     public init() { }
 
@@ -37,6 +42,10 @@ public final class MockLocationService: LocationService {
     
     public func stopUpdatingLocation() {
         
+    }
+    
+    public func getDistance(response: Domain.BusStopInfoResponse) -> String {
+        ""
     }
 }
 #endif

--- a/Projects/FeatureDependency/Sources/Mock/MockStationLIstRepository.swift
+++ b/Projects/FeatureDependency/Sources/Mock/MockStationLIstRepository.swift
@@ -30,7 +30,7 @@ public final class MockStationLIstRepository: StationListRepository {
         
     }
     
-    public func getNearByStopInfo(
+    public func getNearByStop(
         startPointLocation: CLLocation
     ) -> BusStopInfoResponse {
         return (
@@ -41,6 +41,21 @@ public final class MockStationLIstRepository: StationListRepository {
                 longitude: "127.0632387636",
                 latitude: "37.4373210738"
             )
+        )
+    }
+    
+    public func getNearByStopInfo(
+        startPointLocation: CLLocation
+    ) -> (BusStopInfoResponse, String) {
+        return (
+            BusStopInfoResponse(
+                busStopName: "관현사입구",
+                busStopId: "22320",
+                direction: "새쟁이마을",
+                longitude: "127.0632387636",
+                latitude: "37.4373210738"
+            ),
+            ""
         )
     }
     


### PR DESCRIPTION
# 작업내용
## Memory leak 해결
| SearchVC | NearMapVC로 Push | Search로 Dismiss - 해결 전 | Search로 Dismiss - 해결 후 |
| -- | -- | -- | -- |
| 26MB | 168MB | 169MB | 58MB |
| ![image 79](https://github.com/Pepsi-Club/BusComing/assets/109283556/69d2051a-09da-43a1-bbf7-2d3d75b623f9) | ![image 80](https://github.com/Pepsi-Club/BusComing/assets/109283556/54658654-5398-4109-ad0b-a420fc91e28a) | ![image 81](https://github.com/Pepsi-Club/BusComing/assets/109283556/c9be6665-d4a7-49c7-8cb7-94adc7b72531) | ![image 82](https://github.com/Pepsi-Club/BusComing/assets/109283556/e61a1bbe-d741-45e5-a026-02110ed1ec6e) |
- NearMapVC가 dismiss 될 때 NearMap VM / Coordinator, KMController, KakaoMap의 구성요소들이 메모리에서 해제되지 않아
NearMapFlow가 실행되고 dismiss 될 때 마다 약 100MB씩 메모리 사용량이 증가함
### 해결
- VC의 deinit 시점에 VM에서 KMController, KakaoMap의 구성요소 참조 제거
- KakaoMap의 버스정류장 탭 이벤트 핸들러의 NearMapViewModel 캡처 약한 참조로 수정
#### 제거되지 않은 KakaoMap의 구성요소들은 추후 디버깅후 제거예정

## NearMap UseCase / VM 리팩토링
### Flow에 따른 ViewModel 객체을 명명하여 작성하겠습니다.
- VM:Search = Search Flow에서 생성된 VM 객체
- VM:BusStop = BusStop Flow에서 생성된 VM 객체
### VM:Search과 VM:BusStop 모두 UseCase의 정류장 변수에 바인딩된 형태에서 발생하는 이슈
- VM:BusStop의 이벤트가 감지되었을 때 UseCase의 정류장이 업데이트되고 
바인딩된 VM:Search의 onNext 이벤트가 실행됨
  - VM:BusStop의 onNext 이벤트는 실행되지 않음 -> 이유는 파악하지 못하였음
### 해결
- UseCase를 리팩토링하여 정류장 변수를 제거하고 함수로 각각 다른 Observable<정류장>을 return 받아 사용해
다른 객체에게 영향을 주지 않게 수정
### 관련 수정 작업
#### LocationService
- currentLocation의 값을 사용할 수 있게 Behavior로 수정
- BusStopInfoResponse를 받아 현재 위치와 거리 return하는 함수 추가
#### StationRepository
- 정류장을 return하는 함수 (정류장, 거리) return으로 수정

## 리뷰요청
- @MUKER-WON 

## 관련 이슈
close #131, #129