### PR TITLE
[Fix] secondArrivalRemaning 수정

### DIFF
--- a/Projects/Data/Sources/DTO/BusStopArrivalInfoDTO.swift
+++ b/Projects/Data/Sources/DTO/BusStopArrivalInfoDTO.swift
@@ -71,11 +71,13 @@ public extension BusStopArrivalInfoDTO {
                 var secondArrivalRemaining = ""
                 if firstMsgArr.count > 1 {
                     firstArrivalRemaining = firstMsgArr[1]
-                    firstArrivalRemaining.removeLast()
+                    firstArrivalRemaining = 
+                    firstArrivalRemaining.components(separatedBy: "]")[0]
                 }
                 if secondMsgArr.count > 1 {
                     secondArrivalRemaining = secondMsgArr[1]
-                    secondArrivalRemaining.removeLast()
+                    secondArrivalRemaining =
+                    secondArrivalRemaining.components(separatedBy: "]")[0]
                 }
                 let firstArrivalState: ArrivalState
                 let secondArrivalState: ArrivalState

--- a/Projects/DesignSystem/Sources/ArrivalInfoView.swift
+++ b/Projects/DesignSystem/Sources/ArrivalInfoView.swift
@@ -23,6 +23,8 @@ public final class ArrivalInfoView: UIStackView {
         label.font = DesignSystemFontFamily.NanumSquareNeoOTF.light.font(
             size: 12
         )
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.8
         label.textColor = DesignSystemAsset.gray6.color
         return label
     }()


### PR DESCRIPTION
## 작업내용
<img src="https://github.com/Pepsi-Club/BusComing/assets/91649269/373647d9-8eb0-4ec7-b9d5-b766607d54cb" width="300" >
<img src="https://github.com/Pepsi-Club/BusComing/assets/91649269/0ad03432-8d1e-4cc6-ab8d-f9452068e113" width="300" >

- "차고지 출발]" -> "차고지 출발" 로 출력될 수 있게 로직 변경
- "차고지 출발" 잘려서 출력되는 문제 수정

## 리뷰요청
- @yuhaeun-la 

## 관련 이슈
close #148 