### PR TITLE
Fix/#146

### DIFF
--- a/Projects/DesignSystem/Sources/SearchBusStopBtn.swift
+++ b/Projects/DesignSystem/Sources/SearchBusStopBtn.swift
@@ -38,14 +38,22 @@ public final class SearchBusStopBtn: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public override func draw(_ rect: CGRect) {
-        super.draw(rect)
-        guard let titleWidth = titleLabel?.bounds.width,
-              let imgWidth = imageView?.bounds.width
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        guard let titleLabel = titleLabel,
+              let imageView = imageView
         else { return }
-        let space = rect.width * 0.1
-        let padding = rect.width - titleWidth - imgWidth - space
-        configuration?.imagePadding = padding
+        
+        let space: CGFloat = 10
+        titleLabel.frame.origin.x = layoutMargins.left + space
+        
+        let imageViewX 
+        = bounds.width - imageView.bounds.width - layoutMargins.right - space
+        imageView.frame.origin.x = imageViewX
+        
+        titleLabel.center.y = bounds.midY
+        imageView.center.y = bounds.midY
     }
     
     private func makeConfiguration(

--- a/Projects/Feature/AlarmFeature/Sources/ViewController/AddRegularAlarmViewController.swift
+++ b/Projects/Feature/AlarmFeature/Sources/ViewController/AddRegularAlarmViewController.swift
@@ -72,7 +72,7 @@ final class AddRegularAlarmViewController: UIViewController {
     
     private let thirdDescriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = "2. 요일 등록하기"
+        label.text = "3. 요일 등록하기"
         label.font = DesignSystemFontFamily.NanumSquareNeoOTF.regular.font(
             size: 16
         )

--- a/Projects/Feature/AlarmFeature/Sources/ViewController/AddRegularAlarmViewController.swift
+++ b/Projects/Feature/AlarmFeature/Sources/ViewController/AddRegularAlarmViewController.swift
@@ -129,6 +129,8 @@ final class AddRegularAlarmViewController: UIViewController {
         }
         
         let safeArea = view.safeAreaLayoutGuide
+        let screenHeight = UIScreen.main.bounds.height
+        let descriptionGap: CGFloat = screenHeight > 700 ? 35 : 20
         
         NSLayoutConstraint.activate([
             titleLabel.topAnchor.constraint(
@@ -164,7 +166,7 @@ final class AddRegularAlarmViewController: UIViewController {
             
             secondDescriptionLabel.topAnchor.constraint(
                 equalTo: searchBtn.bottomAnchor,
-                constant: 35
+                constant: descriptionGap
             ),
             secondDescriptionLabel.leadingAnchor.constraint(
                 equalTo: firstDescriptionLabel.leadingAnchor
@@ -183,7 +185,7 @@ final class AddRegularAlarmViewController: UIViewController {
             
             thirdDescriptionLabel.topAnchor.constraint(
                 equalTo: timePicker.bottomAnchor,
-                constant: 35
+                constant: descriptionGap
             ),
             thirdDescriptionLabel.leadingAnchor.constraint(
                 equalTo: firstDescriptionLabel.leadingAnchor
@@ -211,11 +213,19 @@ final class AddRegularAlarmViewController: UIViewController {
                 equalTo: safeArea.widthAnchor,
                 multiplier: 0.5
             ),
+        ])
+        
+        if screenHeight > 700 {
             completeBtn.bottomAnchor.constraint(
                 equalTo: safeArea.bottomAnchor,
                 constant: -40
-            )
-        ])
+            ).isActive = true
+        } else {
+            completeBtn.bottomAnchor.constraint(
+                equalTo: safeArea.bottomAnchor,
+                constant: -5
+            ).isActive = true
+        }
     }
     
     private func bind() {

--- a/Projects/Feature/BusStopFeature/Sources/View/BusStopInfoHeaderView.swift
+++ b/Projects/Feature/BusStopFeature/Sources/View/BusStopInfoHeaderView.swift
@@ -95,7 +95,7 @@ public final class BusStopInfoHeaderView: UIView {
     ) {
             busStopNumLb.text = routeId
             busStopNameLb.text = busStopName
-            nextStopNameLb.text = nextStopName
+            nextStopNameLb.text = nextStopName + " 방면"
     }
 }
 

--- a/Projects/Feature/BusStopFeature/Sources/View/BusTableViewCell.swift
+++ b/Projects/Feature/BusStopFeature/Sources/View/BusTableViewCell.swift
@@ -96,7 +96,7 @@ public final class BusTableViewCell: UITableViewCell {
         nextRouteName: String
     ) {
         busNumber.text = routeName
-        nextStopName.text = nextRouteName
+        nextStopName.text = nextRouteName + " 방면"
     }
     
     public func updateFirstArrival(

--- a/Projects/Feature/SettingsFeature/Sources/ViewController/PrivacyWebViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/ViewController/PrivacyWebViewController.swift
@@ -21,6 +21,7 @@ public final class PrivacyWebViewController
         let webView = WKWebView()
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.allowsBackForwardNavigationGestures = true
+        webView.backgroundColor = .white
         return webView
     }()
     private let indicator: UIActivityIndicatorView = {
@@ -41,9 +42,9 @@ public final class PrivacyWebViewController
     
     public override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .white
         
-        view.backgroundColor = .systemBackground
-        
+        navigationController?.navigationBar.barTintColor = .white
         webView.navigationDelegate = self
         
         configureUI()


### PR DESCRIPTION
## 작업내용
[Add Alarm]
iphone SE 3rd gen에서 완료버튼이 요일 설정하는 버튼들과 간섭이 일어나는 문제 발생하여 UIScreen height 값을 받아서 예외처리해주었습니다.
또한 Search bar에 들어오는 text 값의 padding 값이 text 값에 따라 크기가 상이하여 패딩값과 X,Y 값을 지정해주었습니다

[BusStopVC]
headerView와 TVCell의 다음 정거장 방면에 대한 값을 넣었습니다.

| SE 3세대 완료버튼 수정전 | 수정 후/ Search 수정전 | 수정 후 |
| -- | -- | -- |
| ![simulator_screenshot_22899C41-D63C-4ABD-8B81-D2D227BEC9E8](https://github.com/Pepsi-Club/BusComing/assets/133845468/5873d12e-a306-4987-86f9-d4572120c1d9) | ![image 108](https://github.com/Pepsi-Club/BusComing/assets/133845468/be9f50ea-1e27-4b0a-9e22-1809c6e43f6d) | ![image 113](https://github.com/Pepsi-Club/BusComing/assets/133845468/9547844b-2c21-4e28-afc6-553318c33d47) | 

+ 추가)
설정 WKWebView 다크모드와 navigation bar의 barTintColor를 흰색으로 지정했습니다

## 리뷰요청
- @gnksbm 

## 관련 이슈
close #146 